### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'jaxlib',
         'numpy',
         'scipy',
-        'sklearn',
+        'scikit-learn',
     ],
     extras_require=extras,
     classifiers=[


### PR DESCRIPTION
change "sklearn" to "scikit-learn"

when trying to install jax-flows, I get the following:
```
The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.

      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error

      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
```